### PR TITLE
Update typewriters for Claire A + B

### DIFF
--- a/reframework/data/ArchipelagoRE2R/claire/a/typewriters.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/typewriters.json
@@ -37,15 +37,6 @@
     },
 
     { 
-        "name": "Orphanage - Directors Room", 
-        "location_id": 24, 
-        "map_id": 361, 
-        "player_position": [47.45, 0.95, -212.72], 
-        "item_object": "OrphanAsylum_sm41_000_Typewriter01A_control",
-        "line_break": true
-    },
-
-    { 
         "name": "Sewers - Office", 
         "location_id": 17, 
         "map_id": 332, 

--- a/reframework/data/ArchipelagoRE2R/claire/b/typewriters.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/typewriters.json
@@ -37,15 +37,6 @@
     },
 
     { 
-        "name": "Orphanage - Directors Room", 
-        "location_id": 24, 
-        "map_id": 361, 
-        "player_position": [47.45, 0.95, -212.72], 
-        "item_object": "OrphanAsylum_sm41_000_Typewriter01A_control",
-        "line_break": true
-    },
-
-    { 
         "name": "Sewers - Office", 
         "location_id": 17, 
         "map_id": 332, 


### PR DESCRIPTION
Removes `Orphanage` typewriter since it's basically useless as a teleport location now that `Sherry Skip` is a thing.