### PR TITLE
Randomize the T-Bar Handle once again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 reframework/data/AP_REF.json
 reframework/data/ArchipelagoRE2R/_storage
+reframework/autorun/Inspect.lua
+reframework/autorun/Console.lua
+reframework/autorun/EMV Engine
+reframework/data/Console/
+reframework/data/EMV_Engine/

--- a/reframework/autorun/randomizer/DestroyObjects.lua
+++ b/reframework/autorun/randomizer/DestroyObjects.lua
@@ -18,7 +18,8 @@ function DestroyObjects.DestroyAll()
     local destroyables = {
         DestroyObjects.GetPurposeGUI(),
         DestroyObjects.GetAdasSecretWeaponLadder(),
-        DestroyObjects.GetSherrysKey()
+        DestroyObjects.GetSherrysKey(),
+        DestroyObjects.GetSecretRoomTBarPipe()
     }
 
     -- if we talked to Marvin, remove the shutter and the panel interact that lets you put a fuse in it to open the shutter
@@ -61,6 +62,10 @@ end
 
 function DestroyObjects.GetEastHallway2FShutter()
     return Scene.getSceneObject():findGameObject("sm42_003_FireShutter01A_gimmick")
+end
+
+function DestroyObjects.GetSecretRoomTBarPipe()
+    return Scene.getSceneObject():findGameObject("sm41_028_THandleHole02A_underMegami_gimmick")
 end
 
 return DestroyObjects

--- a/reframework/data/ArchipelagoRE2R/claire/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations.json
@@ -1550,8 +1550,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -1648,8 +1648,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -1578,8 +1578,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -1598,8 +1598,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",


### PR DESCRIPTION
Originally didn't rando the T-Bar because using it in Secret Room early would softlock. So this PR removes the T-Bar interactable in Secret Room to make the T-Bar rando-able again.