### PR TITLE
Add Player Inventory nil check to CanReceiveItems

### DIFF
--- a/reframework/autorun/randomizer/Archipelago.lua
+++ b/reframework/autorun/randomizer/Archipelago.lua
@@ -183,10 +183,10 @@ function Archipelago.ItemsReceivedHandler(items_received)
 end
 
 function Archipelago.CanReceiveItems()
-    -- wait until the player is in game, with AP connected, and with an available item box (that's not in use)
+    -- wait until the player is in game, with AP connected, and with an available item box (that's not in use), and with a reachable inventory
     -- before sending any items over
     return Scene.isInGame() and Archipelago.IsConnected() and ItemBox.GetAnyAvailable() ~= nil and not Scene.isUsingItemBox() 
-        and (Scene.isCharacterClaire() or Scene.isCharacterLeon())
+        and Inventory.GetPlayerInventory() ~= nil and (Scene.isCharacterClaire() or Scene.isCharacterLeon())
 end
 
 function Archipelago.CanBeKilled()

--- a/reframework/autorun/randomizer/Inventory.lua
+++ b/reframework/autorun/randomizer/Inventory.lua
@@ -1,24 +1,33 @@
 local Inventory = {}
 
-function Inventory.GetMaxSlots()
+function Inventory.GetPlayerInventory()
     local inventoryManager = sdk.get_managed_singleton(sdk.game_namespace("gamemastering.InventoryManager"))
+
+    if inventoryManager == nil then
+        return nil
+    end
+
     local playerInventory = inventoryManager:get_CurrentInventory()
+
+    return playerInventory
+end
+
+function Inventory.GetMaxSlots()
+    local playerInventory = Inventory.GetPlayerInventory()
     local playerCurrentMaxSlots = playerInventory:get_field("_CurrentSlotSize")
 
     return playerCurrentMaxSlots
 end
 
 function Inventory.IncreaseMaxSlots(amount)
-    local inventoryManager = sdk.get_managed_singleton(sdk.game_namespace("gamemastering.InventoryManager"))
-    local playerInventory = inventoryManager:get_CurrentInventory()
+    local playerInventory = Inventory.GetPlayerInventory()
     local playerCurrentMaxSlots = playerInventory:get_field("_CurrentSlotSize")
 
     playerInventory:call("set_CurrentSlotSize", playerCurrentMaxSlots + amount)
 end
 
 function Inventory.GetCurrentItems()
-    local inventoryManager = sdk.get_managed_singleton(sdk.game_namespace("gamemastering.InventoryManager"))
-    local playerInventory = inventoryManager:get_CurrentInventory()
+    local playerInventory = Inventory.GetPlayerInventory()
     local playerInventorySlots = playerInventory:get_field("_Slots")
     local playerCurrentMaxSlots = playerInventory:get_field("_CurrentSlotSize")
     local mItems = playerInventorySlots:get_field("mItems")
@@ -75,8 +84,7 @@ function Inventory.HasItemId(item_id, weapon_id)
 end
 
 function Inventory.AddItem(itemId, weaponId, weaponParts, bulletId, count)
-    local inventoryManager = sdk.get_managed_singleton(sdk.game_namespace("gamemastering.InventoryManager"))
-    local playerInventory = inventoryManager:get_CurrentInventory()
+    local playerInventory = Inventory.GetPlayerInventory()
     local playerInventorySlots = playerInventory:get_field("_Slots")
     local mItems = playerInventorySlots:get_field("mItems")
     local slotEmpty = playerInventory:getSlotEmpty()
@@ -102,8 +110,7 @@ function Inventory.AddItem(itemId, weaponId, weaponParts, bulletId, count)
 end
 
 function Inventory.SwapItem(fromItemIds, fromWeaponIds, itemId, weaponId, weaponParts, bulletId, count)
-    local inventoryManager = sdk.get_managed_singleton(sdk.game_namespace("gamemastering.InventoryManager"))
-    local playerInventory = inventoryManager:get_CurrentInventory()
+    local playerInventory = Inventory.GetPlayerInventory()
     local playerInventorySlots = playerInventory:get_field("_Slots")
     local playerCurrentMaxSlots = playerInventory:get_field("_CurrentSlotSize")
     local mItems = playerInventorySlots:get_field("mItems")


### PR DESCRIPTION
Wasn't able to reproduce the sporadic issues that some people have reported with not receiving hip pouches at the start of a rando. But because it's hip pouches, thinking the issue might be a non-existent player inventory object, since hip pouches are applied directly to the inventory object instead of being "received".

So this PR adds an additional check for CanReceiveItems that looks for the existence of the player inventory before saying it's okay to receive anything.