### PR TITLE
skip next ui workaround - client

### DIFF
--- a/reframework/autorun/randomizer/Items.lua
+++ b/reframework/autorun/randomizer/Items.lua
@@ -4,6 +4,10 @@ Items.lastInteractable = nil
 Items.cancelNextUI = false
 Items.cancelNextSafeUI = false
 Items.cancelNextStatueUI = false
+Items.skipUiList = {}
+Items.skipUiList["sm44_006_LeonDesk01A_control"] = true
+Items.skipUiList["sm44_004_WeskerDesk01A_control"] = true
+Items.skipUiList["Test_2_1_DrawerDesk_1FE1_control"] = true
 
 function Items.Init()
     if not Items.isInit then
@@ -69,6 +73,11 @@ function Items.SetupInteractHook()
             end
 
             return
+        end
+		
+        -- force exit item pick up ui on some interactions
+        if Items.skipUiList[item_name] ~= nil then
+            Items.cancelNextUI = true
         end
 
         -- if item_name and item_folder_path are not nil (even empty strings), do a location lookup to see if we should get an item

--- a/reframework/data/ArchipelagoRE2R/claire/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations.json
@@ -86,10 +86,9 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "Test_2_1_DrawerDesk_1FE1_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem",
-        "randomized": 0
+        "item_object": "sm70_109",
+        "parent_object": "ItemPos_TreasureA_Claire",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem"
     },
     {
         "name": "Second Stall",
@@ -253,10 +252,9 @@
         "region": "West Office",
         "original_item": "Speed Loader - SLS 60",
         "condition": {},    
-        "item_object": "sm44_006_LeonDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Claire_S02_0100/1FW/WestOffice/LeonDesk",
-        "randomized": 0
+        "item_object": "sm71_904",
+        "parent_object": "ItemPositionsCollider",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Claire_S02_0100/1FW/WestOffice/LeonDesk"
     },
     {
         "name": "Outside Darkroom 1",
@@ -373,10 +371,20 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "sm44_004_WeskerDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire",
-        "randomized": 0
+        "item_object": "sm77_006",
+        "parent_object": "ItemPos_TreasureB_Claire",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
+    },
+    {
+        "name": "Hiding Place Secret Film",
+        "region": "STARS Office",
+        "original_item": "Film - Rising Rookie",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm72_201",
+        "parent_object": "itempos_sm72_201_FilmB_PosweskerDesk",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
     },
     {
         "name": "Boxes By Door",

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -152,10 +152,9 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "Test_2_1_DrawerDesk_1FE1_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem",
-        "randomized": 0
+        "item_object": "sm70_109",
+        "parent_object": "ItemPos_TreasureA_Claire",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem"
     },
     {
         "name": "Second Stall",
@@ -318,10 +317,9 @@
         "region": "West Office",
         "original_item": "Speed Loader - SLS 60",
         "condition": {},    
-        "item_object": "sm44_006_LeonDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Claire_S02_0100/1FW/WestOffice/LeonDesk",
-        "randomized": 0
+        "item_object": "sm71_904",
+        "parent_object": "ItemPositionsCollider",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Claire_S02_0100/1FW/WestOffice/LeonDesk"
     },
     {
         "name": "Outside Darkroom 1",
@@ -438,10 +436,20 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "sm44_004_WeskerDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire",
-        "randomized": 0
+        "item_object": "sm77_006",
+        "parent_object": "ItemPos_TreasureB_Claire",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
+    },
+    {
+        "name": "Hiding Place Secret Film",
+        "region": "STARS Office",
+        "original_item": "Film - Rising Rookie",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm72_201",
+        "parent_object": "itempos_sm72_201_FilmB_PosweskerDesk",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
     },
     {
         "name": "Boxes By Door",

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -86,10 +86,9 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "Test_2_1_DrawerDesk_1FE1_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem",
-        "randomized": 0
+        "item_object": "sm70_110",
+        "parent_object": "ItemPos_TreasureA_Leon",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem"
     },
     {
         "name": "Second Stall",
@@ -253,10 +252,9 @@
         "region": "West Office",
         "original_item": "High-Capacity Magazine - Matilda",
         "condition": {},    
-        "item_object": "sm44_006_LeonDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Leon_S02_0100/1FW/WestOffice/LeonDesk",
-        "randomized": 0
+        "item_object": "sm71_901",
+        "parent_object": "ItemPositionsCollider",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Leon_S02_0100/1FW/WestOffice/LeonDesk"
     },
     {
         "name": "Outside Darkroom 1",
@@ -373,10 +371,20 @@
         "condition": {
             "items": ["Film - Hiding Place"]
         },    
-        "item_object": "sm44_004_WeskerDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON",
-        "randomized": 0
+        "item_object": "sm77_005",
+        "parent_object": "ItemPos_TreasureB_Leon",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
+    },
+    {
+        "name": "Hiding Place Secret Film",
+        "region": "STARS Office",
+        "original_item": "Film - Rising Rookie",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm72_201",
+        "parent_object": "itempos_sm72_201_FilmB_PosweskerDesk",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
     },
     {
         "name": "Boxes By Door",

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -146,6 +146,17 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/PressRoom"
     },
     {
+        "name": "Hiding Place Drawer",
+        "region": "Press Room",
+        "original_item": "Flamethrower Fuel",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm70_110",
+        "parent_object": "ItemPos_TreasureA_Leon",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/PressRoom/DrawerDesk_1FEPressRoom_TreasurePhotoItem"
+    },
+    {
         "name": "Second Stall",
         "region": "Bathroom",
         "original_item": "First Aid Spray",
@@ -306,10 +317,9 @@
         "region": "West Office",
         "original_item": "High-Capacity Magazine - Matilda",
         "condition": {},    
-        "item_object": "sm44_006_LeonDesk01A_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Leon_S02_0100/1FW/WestOffice/LeonDesk",
-        "randomized": 0
+        "item_object": "sm71_901",
+        "parent_object": "ItemPositionsCollider",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Leon_S02_0100/1FW/WestOffice/LeonDesk"
     },
     {
         "name": "Outside Darkroom 1",
@@ -418,6 +428,28 @@
         "item_object": "sm70_101",
         "parent_object": "LEON_sm70_101_ShotgunB",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/Corrider"
+    },
+    {
+        "name": "Hiding Place Drawer",
+        "region": "STARS Office",
+        "original_item": "Red Dot Sight - Lightning Hawk",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm77_005",
+        "parent_object": "ItemPos_TreasureB_Leon",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
+    },
+    {
+        "name": "Hiding Place Secret Film",
+        "region": "STARS Office",
+        "original_item": "Film - Rising Rookie",
+        "condition": {
+            "items": ["Film - Hiding Place"]
+        },    
+        "item_object": "sm72_201",
+        "parent_object": "itempos_sm72_201_FilmB_PosweskerDesk",
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
     },
     {
         "name": "Boxes By Door",


### PR DESCRIPTION
-client check on interaction for wesker's desk, leon's desk and press room drawer 
-add missing locations related to hiding place film, allowing them to be randomized 
-reworks existing locations related to hiding place film, allowing them to be randomized
-rookie's table is now able to be randomized

works on my side, but my testing was done on a older versions of the game, might want to double check at least one of those places (rookie's table is the easiest one)