### PR TITLE
Fix Leon's Rising Rookie and Lion Statue film codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ reframework/autorun/Console.lua
 reframework/autorun/EMV Engine
 reframework/data/Console/
 reframework/data/EMV_Engine/
+reframework/autorun_disabled

--- a/reframework/data/ArchipelagoRE2R/claire/items.json
+++ b/reframework/data/ArchipelagoRE2R/claire/items.json
@@ -340,16 +340,14 @@
         "name": "Film - Commemorative",
         "decimal": "74",
         "count": 1,
-        "progression": 1,
-        "comments": "I swapped a few of these around, I think they're right but I have been wrong before."
+        "progression": 1
     },
     {
         "type": "Gating",
         "name": "Film - Lion Statue",
         "decimal": "76",
         "count": 1,
-        "progression": 1,
-        "comments": "I swapped a few of these around, I think they're right but I have been wrong before."
+        "progression": 1
     },
     {
         "type": "Gating",
@@ -370,8 +368,7 @@
         "name": "Film - Rising Rookie",
         "decimal": "73",
         "count": 1,
-        "progression": 1,
-        "comments": "I swapped a few of these around, I think they're right but I have been wrong before."
+        "progression": 1
     },
 
     {

--- a/reframework/data/ArchipelagoRE2R/leon/items.json
+++ b/reframework/data/ArchipelagoRE2R/leon/items.json
@@ -332,16 +332,14 @@
         "name": "Film - Commemorative",
         "decimal": "74",
         "count": 1,
-        "progression": 1,
-        "comments": "The hex is a guess and could be wrong."
+        "progression": 1
     },
     {
         "type": "Gating",
         "name": "Film - Lion Statue",
-        "decimal": "73",
+        "decimal": "76",
         "count": 1,
-        "progression": 1,
-        "comments": "The hex is a guess and could be wrong."
+        "progression": 1
     },
     {
         "type": "Gating",
@@ -360,10 +358,9 @@
     {
         "type": "Gating",
         "name": "Film - Rising Rookie",
-        "decimal": "76",
+        "decimal": "73",
         "count": 1,
-        "progression": 1,
-        "comments": "The hex is a guess and could be wrong."
+        "progression": 1
     },
 
     {


### PR DESCRIPTION
Currently, these are swapped, so they give the wrong one. Apparently, no one ever looks at the Lion Statue film :stuck_out_tongue_winking_eye: 