### PR TITLE
Change ammo pack rando Max to sensible counts

### DIFF
--- a/reframework/autorun/randomizer/Archipelago.lua
+++ b/reframework/autorun/randomizer/Archipelago.lua
@@ -574,7 +574,27 @@ function Archipelago.ReceiveItem(item_name, sender, is_randomized)
             local random_min = 1
             local random_max = math.ceil(count * 1.5) -- originally did 2x here, but high rolls made things too easy, this balanced out some
 
-            if pmod == "Max" then count = 2000 end -- let the game figure out what part of 2000 it can fulfill :)
+            -- if Max, cap the ammo at the game's defined maximum for each ammo pack (if the pack count is green in-game, it's at the max)
+            if pmod == "Max" then 
+                local ammo_maxes = {
+                    ["Handgun Ammo"] = 60,
+                    ["Large-Caliber Handgun Ammo"] = 60,
+                    ["Shotgun Shells"] = 20,
+                    ["Submachine Gun Ammo"] = 200,
+                    ["MAG Ammo"] = 20,
+                    ["High-Powered Rounds"] = 20,
+                    ["Flame Rounds"] = 10,
+                    ["Acid Rounds"] = 10,
+                    ["Flamethrower Fuel"] = 400,
+                    ["Needle Cartridges"] = 100
+                }
+
+                if ammo_maxes[item_ref.name] ~= nil then
+                    count = ammo_maxes[item_ref.name]
+                else
+                    count = 500
+                end
+            end
             if pmod == "Double" then count = count * 2 end
             if pmod == "Half" then count = math.ceil(count / 2) end
             if pmod == "Only Three" then count = 3 end


### PR DESCRIPTION
The ammo pack quantity rando setting "Max" was originally just added as a blanket 2000 count, with the idea that the game would just cap it at whatever the max is. Well... turns out, if that ammo gets sent to the box, the game fulfills the *entire* 2000. And this happens a lot.

So instead of absurd inflated counts, "Max" now gives a pack at the game's maximum for that item's ammo pack. Which makes for more realistic numbers, but still inflated for a "Max" setting.