### PR TITLE
Add Mini-Minigun to support Oops All Miniguns

### DIFF
--- a/reframework/data/ArchipelagoRE2R/claire/items.json
+++ b/reframework/data/ArchipelagoRE2R/claire/items.json
@@ -504,7 +504,13 @@
         "count": 400,
         "progression": 0
     },
-
+    {
+        "type": "Weapon",
+        "name": "Mini-Minigun",
+        "decimal": "50",
+        "count": 50,
+        "progression": 0
+    },
     {
         "type": "Subweapon",
         "name": "Combat Knife",


### PR DESCRIPTION
Creates a 50 ammo version of the minigun to make Oops All Miniguns less stupid

Meant to be used in conjunction with [PR 43](https://github.com/FuzzyGamesOn/RE2R_AP_World/pull/43) on the apworld