### PR TITLE
Check for apworld version mismatch on connect

### DIFF
--- a/reframework/autorun/randomizer/Archipelago.lua
+++ b/reframework/autorun/randomizer/Archipelago.lua
@@ -1,6 +1,7 @@
 local Archipelago = {}
 Archipelago.seed = nil
 Archipelago.slot = nil
+Archipelago.apworld_version = nil -- comes over in slot data
 Archipelago.starting_weapon = nil -- comes over in slot data
 Archipelago.ammo_pack_modifier = nil -- comes over in slot data
 Archipelago.ammo_pack_type_amount = {} -- used if pack modifier is "random by type"
@@ -94,6 +95,10 @@ function Archipelago.SlotDataHandler(slot_data)
 
     if slot_data.starting_weapon ~= nil then
         Archipelago.starting_weapon = slot_data.starting_weapon
+    end
+
+    if slot_data.apworld_version ~= nil then
+        Archipelago.apworld_version = slot_data.apworld_version
     end
 
     if slot_data.ammo_pack_modifier ~= nil then

--- a/reframework/autorun/randomizer/Manifest.lua
+++ b/reframework/autorun/randomizer/Manifest.lua
@@ -1,6 +1,6 @@
 local Manifest = {}
 
 Manifest.mod_name = "ArchipelagoRE2R"
-Manifest.version = "0.2.5"
+Manifest.version = "0.2.6"
 
 return Manifest

--- a/reframework/autorun/randomizer/Tools.lua
+++ b/reframework/autorun/randomizer/Tools.lua
@@ -4,7 +4,9 @@ function Tools.ShowGUI()
     local scenario_text = '   (not connected)'
     local deathlink_text = '   (not connected)'
     local deathlink_color = AP_REF.HexToImguiColor('FFFFFF')
-    
+    local version_text = '   ' .. tostring(Manifest.version)
+    local version_mismatch = false
+
     -- if the lookups contain data, then we're connected, so do everything that needs connection
     if Lookups.character and Lookups.scenario then
         scenario_text = "   " .. Lookups.character:gsub("^%l", string.upper) .. " " .. string.upper(Lookups.scenario) .. 
@@ -16,6 +18,18 @@ function Tools.ShowGUI()
         else
             deathlink_text = "   Off"
             deathlink_color = AP_REF.HexToImguiColor('777777')
+        end
+
+        if Archipelago.apworld_version == nil or Archipelago.apworld_version ~= Manifest.version then
+            if Archipelago.apworld_version ~= nil then
+                version_text = version_text .. ' (world is ' .. Archipelago.apworld_version .. ')'
+            else
+                version_text = version_text .. ' (world is outdated)'
+            end
+
+            version_mismatch = true
+        else
+            version_text = version_text .. ' (matches)'
         end
     end
     
@@ -31,7 +45,13 @@ function Tools.ShowGUI()
     )
 
     imgui.text_colored("Mod Version Number: ", -10825765)
-    imgui.text("   " .. tostring(Manifest.version))
+    
+    if version_mismatch then
+        imgui.text_colored(version_text, AP_REF.HexToImguiColor('fa3d2f'))
+    else
+        imgui.text(version_text)
+    end
+
     imgui.new_line()
     imgui.text_colored("AP Scenario & Difficulty:   ", -10825765)
     imgui.text(scenario_text)


### PR DESCRIPTION
Continuation of the PR that adds the apworld version to slot data: https://github.com/FuzzyGamesOn/RE2R_AP_World/pull/47

This PR makes the client show the version number in red if it doesn't match the apworld version that was generated with.