### PR TITLE
Add Joint Plug to G5 Condition

### DIFF
--- a/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
@@ -611,6 +611,8 @@
 	{ 
         "from": "Path to G4",
         "to": "G5 Ending",
-        "condition": {}
+        "condition": {
+             "items": ["Joint Plug"]
+         }
     }
 ]

--- a/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
@@ -623,9 +623,11 @@
         "to": "Path to Super Tyrant",
         "condition": {}
     },
-	{ 
+    { 
         "from": "Path to Super Tyrant",
         "to": "G5 Ending",
-        "condition": {}
+        "condition": {
+	    "items": ["Joint Plug"]
+        }
     }
 ]


### PR DESCRIPTION
Even though it matters little, making the same change here to keep in line with apworld.

Fix logic issue by adding Joint Plug as a condition to accessing G5, courtesy of @neurodaemon in the discord thread