### PR TITLE
Make the East Hallway shutter not open until an autosave has happened

### DIFF
--- a/reframework/autorun/randomizer/Items.lua
+++ b/reframework/autorun/randomizer/Items.lua
@@ -107,8 +107,9 @@ function Items.SetupInteractHook()
                 GUI.AddText("It is recommended that you complete all of the checks in Sewers prior to leaving.")
             end
 
-            -- when Marvin's first cutscene plays, set a flag so we can remove the Main Hall shutter
-            if item_name == "CFPlayExtra_GoHall" and item_folder_path == "RopewayContents/World/Location_RPD/LocationLevel_RPD/Scenario/S02_0000/1FE/1FE_GoHall" then
+            -- sometime after Marvin's first cutscene plays, set a flag so we can remove the Main Hall shutter
+            -- this was changed from Marvin's location to the vault spot in Operations Room because that spot triggers a guaranteed autosave
+            if item_name == "sm49_313_GoThroughMotion" and item_folder_path == "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0100/Leon_S02_0100/1FW/MissionRoom/UpperWindow" then
                 Storage.talkedToMarvin = true
             end
 

--- a/reframework/autorun/randomizer/Typewriters.lua
+++ b/reframework/autorun/randomizer/Typewriters.lua
@@ -20,7 +20,7 @@ function Typewriters.AddUnlockedText(name, item_name, no_save_warning)
 
     if #typewriterText > 0 then     
         if typewriterText == "RPD - Lobby" and string.lower(Lookups.scenario) == "a" and not Storage.talkedToMarvin then
-            GUI.AddText("Lobby typewriter teleport will unlock after you talk to Marvin for the first time.")
+            GUI.AddText("Lobby typewriter teleport will unlock after you vault the window in Operations Room.")
         else
             GUI.AddTexts({
                 { message="Unlocked " },


### PR DESCRIPTION
We've had a few people softlock themselves by receiving a deathlink before they got to a save/autosave after talking to Marvin. At respawn, they're sent back to East Hallway but the shutter is now open, so they miss the trigger for the "pull through shutter" cutscene, which breaks their game from that point on.

So this PR moves the flag that triggers the removal of the East Hallway shutter to the Operations Room window that you vault through, which has an autosave right in front of it that you're respawned to on death.