### PR TITLE
Valve Handle + Hardcore Fixes

### DIFF
--- a/reframework/data/ArchipelagoRE2R/claire/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations.json
@@ -2374,8 +2374,8 @@
         "region": "Path to G4",
         "condition": {
             "items": [
-                "Spade Key", "Heart Key", "Diamond Key",
-                "Bolt Cutters", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Spade Key", "Heart Key", "Diamond Key", 
+                "Bolt Cutters", "Valve Handle", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", 
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/reframework/data/ArchipelagoRE2R/claire/a/locations_hardcore.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations_hardcore.json
@@ -99,7 +99,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2", 
+        "name": "On Table 2", 
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -2512,7 +2512,7 @@
         "condition": {
             "items": [
                 "Courtyard Key", "Spade Key", "Heart Key", "Diamond Key",
-                "Bolt Cutters", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations_hardcore.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations_hardcore.json
@@ -108,7 +108,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2", 
+        "name": "On Table 2", 
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
@@ -608,11 +608,11 @@
         "to": "Path to G4",
         "condition": {}
     },
-	{ 
+    { 
         "from": "Path to G4",
         "to": "G5 Ending",
         "condition": {
-             "items": ["Joint Plug"]
-         }
+            "items": ["Joint Plug"]
+        }
     }
 ]

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -2405,7 +2405,7 @@
         "condition": {
             "items": [
                 "Spade Key", "Club Key", "Diamond Key",
-                "Bolt Cutters", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", 
                 "Square Crank", "Fuse - Break Room Hallway", "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations_hardcore.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations_hardcore.json
@@ -90,7 +90,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -2479,7 +2479,7 @@
         "condition": {
             "items": [
                 "Courtyard Key", "Spade Key", "Club Key", "Diamond Key",
-                "Bolt Cutters", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
                 "Square Crank", "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations_hardcore.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations_hardcore.json
@@ -99,7 +99,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
@@ -623,11 +623,11 @@
         "to": "Path to Super Tyrant",
         "condition": {}
     },
-    { 
+	{ 
         "from": "Path to Super Tyrant",
         "to": "G5 Ending",
         "condition": {
-	    "items": ["Joint Plug"]
+            "items": ["Joint Plug"]
         }
     }
 ]


### PR DESCRIPTION
Adds Valve Handle to the list of items needed for Victory, and fixes hardcore location from having the wrong name "Table Location 2" to "On Table 2" to mirror change in standard.