### PR TITLE
Warn player if they're playing a different scenario than the one in their YAML

### DIFF
--- a/reframework/autorun/randomizer.lua
+++ b/reframework/autorun/randomizer.lua
@@ -107,6 +107,7 @@ re.on_frame(function ()
     end
 
     if Scene:isInGame() or Scene:isGameOver() then
+        GUI.CheckScenarioWarning()
         GUI.CheckForAndDisplayMessages()
     end
 

--- a/reframework/autorun/randomizer/Scene.lua
+++ b/reframework/autorun/randomizer/Scene.lua
@@ -79,6 +79,22 @@ function Scene.getSurvivorType()
     return -1
 end
 
+function Scene.getScenarioType()
+    local mainFlowManager = Scene.getMainFlowManager();
+    
+    if mainFlowManager ~= nil then
+        local scenarioTypeSetting = mainFlowManager:call("get_CurrentScenarioType")
+
+        if scenarioTypeSetting ~= nil then
+            return scenarioTypeSetting
+        end
+
+        return -1
+    end
+
+    return -1 
+end
+
 function Scene.getGUIItemBox()
     if Scene.guiItemBox ~= nil then
         return Scene.guiItemBox
@@ -125,6 +141,22 @@ end
 
 function Scene.isCharacterSherry()
     return Scene.getSurvivorType() == 3
+end
+
+function Scene.isScenarioLeonA()
+    return Scene.getScenarioType() == 0
+end
+
+function Scene.isScenarioLeonB()
+    return Scene.getScenarioType() == 2
+end
+
+function Scene.isScenarioClaireA()
+    return Scene.getScenarioType() == 1
+end
+
+function Scene.isScenarioClaireB()
+    return Scene.getScenarioType() == 3
 end
 
 function Scene.getCurrentLocation()


### PR DESCRIPTION
This has come up a couple times, where players don't realize that the B scenarios are the "2nd" scenario in-game (likely because they haven't unlocked "2nd" scenarios) and just think they're picking an alternate via AP alone.

So this PR adds a check that warns them if they're playing the wrong scenario.