### PR TITLE
Fixing chess plug panels

### DIFF
--- a/reframework/autorun/randomizer/Items.lua
+++ b/reframework/autorun/randomizer/Items.lua
@@ -41,6 +41,7 @@ function Items.SetupInteractHook()
         if item_name and item_folder and feedbackParent then
             item_transform = sdk.to_managed_object(feedbackParent:call('get_Transform()'))
             item_transform_parent = sdk.to_managed_object(item_transform:call('get_Parent()'))
+            item_transform_root = sdk.to_managed_object(item_transform:call('get_Root()'))
 
             if item_transform_parent then
                 item_parent = sdk.to_managed_object(item_transform_parent:call('get_GameObject()'))
@@ -48,7 +49,25 @@ function Items.SetupInteractHook()
                 item_positions = item_parent:call("getComponent(System.Type)", sdk.typeof(sdk.game_namespace("item.ItemPositions")))
 
                 if not item_name or not item_folder_path or not item_positions then
-                    item_parent_name = "" -- unset so we know it's a non-standard item location
+                    -- if the location name has "PlugPlace", then it's a chess plug panel
+                    -- so use the same name scheme that's expected below to properly target the plug panel
+                    if string.find(item_name, "PlugPlace") then
+                        item_parent_name = item_name
+                    
+                    -- otherwise, unset so we know it's a non-standard item location
+                    else 
+                        item_parent_name = ""                     
+                    end
+                elseif item_transform_root then
+                    local item_root = sdk.to_managed_object(item_transform_root:call('get_GameObject()'))
+                    local item_root_name = item_root:call("get_Name()")
+
+                    -- if the root level transform is a gameobject that is a "plug place", we're dealing with a chess plug panel
+                    -- so we want to use the identifier(s) for the panel itself, not the plug that was there
+                    if string.find(item_root_name, "PlugPlace") then
+                        item_name = item_root_name:gsub("gimmick", "control")
+                        item_parent_name = item_root_name:gsub("gimmick", "control")
+                    end
                 end
             else 
                 -- non-item things like typewriters here, so do typewriter interaction tracking

--- a/reframework/data/ArchipelagoRE2R/claire/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations.json
@@ -1503,8 +1503,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "sm73_154",
-        "parent_object": "ItemPositions_4",
+        "item_object": "Rook_sm42_215_PlugPlace02A_control",
+        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1512,8 +1512,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "sm73_114",
-        "parent_object": "ItemPositions_0",
+        "item_object": "King_sm42_215_PlugPlace02A_control",
+        "parent_object": "King_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1521,8 +1521,8 @@
         "region": "Monitor Room",
         "original_item": "Pawn Plug",
         "condition": {},    
-        "item_object": "sm73_155",
-        "parent_object": "ItemPositions_5",
+        "item_object": "Pawn_sm42_215_PlugPlace02A_control",
+        "parent_object": "Pawn_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1629,8 +1629,8 @@
         "region": "Waterway Overpass",
         "original_item": "Rook Plug",
         "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
+        "item_object": "sm42_208_PlugPlace01A_control",
+        "parent_object": "sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
     },
     {
@@ -1683,8 +1683,8 @@
         "region": "Supplies Storage Room",
         "original_item": "Queen Plug",
         "condition": {},    
-        "item_object": "sm73_156",
-        "parent_object": "ItemPositions_3",
+        "item_object": "QueenA_sm42_208_PlugPlace01A_control",
+        "parent_object": "QueenA_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick"
     },
     {
@@ -1692,8 +1692,8 @@
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
         "condition": {},    
-        "item_object": "sm73_116",
-        "parent_object": "ItemPositions_2",
+        "item_object": "KingB_sm42_208_PlugPlace01A_control",
+        "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",
         "randomized": 0
     },

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -1610,8 +1610,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "sm73_154",
-        "parent_object": "ItemPositions_4",
+        "item_object": "Rook_sm42_215_PlugPlace02A_control",
+        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1619,8 +1619,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "sm73_114",
-        "parent_object": "ItemPositions_0",
+        "item_object": "King_sm42_215_PlugPlace02A_control",
+        "parent_object": "King_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1628,8 +1628,8 @@
         "region": "Monitor Room",
         "original_item": "Pawn Plug",
         "condition": {},    
-        "item_object": "sm73_155",
-        "parent_object": "ItemPositions_5",
+        "item_object": "Pawn_sm42_215_PlugPlace02A_control",
+        "parent_object": "Pawn_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1736,8 +1736,8 @@
         "region": "Waterway Overpass",
         "original_item": "Rook Plug",
         "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
+        "item_object": "sm42_208_PlugPlace01A_control",
+        "parent_object": "sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
     },
     {
@@ -1790,8 +1790,8 @@
         "region": "Supplies Storage Room",
         "original_item": "Queen Plug",
         "condition": {},    
-        "item_object": "sm73_156",
-        "parent_object": "ItemPositions_3",
+        "item_object": "QueenA_sm42_208_PlugPlace01A_control",
+        "parent_object": "QueenA_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick"
     },
     {
@@ -1799,8 +1799,8 @@
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
         "condition": {},    
-        "item_object": "sm73_116",
-        "parent_object": "ItemPositions_2",
+        "item_object": "KingB_sm42_208_PlugPlace01A_control",
+        "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",
         "randomized": 0
     },

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -1545,8 +1545,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "sm73_154",
-        "parent_object": "ItemPositions_4",
+        "item_object": "Rook_sm42_215_PlugPlace02A_control",
+        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1554,8 +1554,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "sm73_114",
-        "parent_object": "ItemPositions_0",
+        "item_object": "King_sm42_215_PlugPlace02A_control",
+        "parent_object": "King_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1563,8 +1563,8 @@
         "region": "Monitor Room",
         "original_item": "Pawn Plug",
         "condition": {},    
-        "item_object": "sm73_155",
-        "parent_object": "ItemPositions_5",
+        "item_object": "Pawn_sm42_215_PlugPlace02A_control",
+        "parent_object": "Pawn_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1671,8 +1671,8 @@
         "region": "Waterway Overpass",
         "original_item": "Rook Plug",
         "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
+        "item_object": "sm42_208_PlugPlace01A_control",
+        "parent_object": "sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
     },
     {
@@ -1716,8 +1716,8 @@
         "region": "Supplies Storage Room",
         "original_item": "Queen Plug",
         "condition": {},    
-        "item_object": "sm73_156",
-        "parent_object": "ItemPositions_3",
+        "item_object": "QueenA_sm42_208_PlugPlace01A_control",
+        "parent_object": "QueenA_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick"
     },
     {
@@ -1725,8 +1725,8 @@
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
         "condition": {},    
-        "item_object": "sm73_116",
-        "parent_object": "ItemPositions_2",
+        "item_object": "KingB_sm42_208_PlugPlace01A_control",
+        "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",
         "randomized": 0
     },

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -1589,8 +1589,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "sm73_154",
-        "parent_object": "ItemPositions_4",
+        "item_object": "Rook_sm42_215_PlugPlace02A_control",
+        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1598,8 +1598,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "sm73_114",
-        "parent_object": "ItemPositions_0",
+        "item_object": "King_sm42_215_PlugPlace02A_control",
+        "parent_object": "King_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1607,8 +1607,8 @@
         "region": "Monitor Room",
         "original_item": "Pawn Plug",
         "condition": {},    
-        "item_object": "sm73_155",
-        "parent_object": "ItemPositions_5",
+        "item_object": "Pawn_sm42_215_PlugPlace02A_control",
+        "parent_object": "Pawn_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1715,8 +1715,8 @@
         "region": "Waterway Overpass",
         "original_item": "Rook Plug",
         "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
+        "item_object": "sm42_208_PlugPlace01A_control",
+        "parent_object": "sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
     },
     {
@@ -1760,8 +1760,8 @@
         "region": "Supplies Storage Room",
         "original_item": "Queen Plug",
         "condition": {},    
-        "item_object": "sm73_156",
-        "parent_object": "ItemPositions_3",
+        "item_object": "QueenA_sm42_208_PlugPlace01A_control",
+        "parent_object": "QueenA_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick"
     },
     {
@@ -1769,8 +1769,8 @@
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
         "condition": {},    
-        "item_object": "sm73_116",
-        "parent_object": "ItemPositions_2",
+        "item_object": "KingB_sm42_208_PlugPlace01A_control",
+        "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",
         "randomized": 0
     },


### PR DESCRIPTION
Okay! So, chess plug panels have been a pain for a long time because the interactions are different objects depending on the state of the panel when you interact. And I didn't want to deal with the complications from that. So I made all the chess plug panels identify by their highest-level (root) transform game object's name instead, which is uniform regardless of the state.

This will have an accompanying apworld PR that updates all the plug panel locations as well, just like they are in this PR.