### PR TITLE
Fix CutsceneObjects to not rely on EMV Engine

### DIFF
--- a/reframework/autorun/randomizer/CutsceneObjects.lua
+++ b/reframework/autorun/randomizer/CutsceneObjects.lua
@@ -15,7 +15,7 @@ function CutsceneObjects.Init()
 end
 
 function CutsceneObjects.DispersalCartridge()
-    local dispersalObject = Helpers.gameObject("sm42_222_SprayingMachine01A_control")
+    local dispersalObject = Scene.getSceneObject():findGameObject("sm42_222_SprayingMachine01A_control")
     if not dispersalObject then
         return
     end


### PR DESCRIPTION
This change simply fixes the CutsceneObjects.lua to not rely on the EMV-Engine because most will not have it installed.

Forgot that I had made a change to Helpers.lua months ago on my end and never pushed it to the repo.