### PR TITLE
Fix chess plug panels for B scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ reframework/autorun/EMV Engine
 reframework/data/Console/
 reframework/data/EMV_Engine/
 reframework/autorun_disabled
+
+# moved my EMV Engine console out of autorun when not using it to better detect EMV-only errors
+reframework/Console.lua

--- a/reframework/data/ArchipelagoRE2R/claire/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/locations.json
@@ -7,7 +7,7 @@
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Main Desk",
@@ -17,7 +17,7 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Marvin's Knife",
@@ -37,7 +37,7 @@
         "item_object": "sm42_176_HieroglyphicDialLock01A_ForLion_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0000/Hall/LionStatue",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "2F Couch",
@@ -47,7 +47,7 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100_HandgunB",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Shelves",

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -1184,6 +1184,7 @@
         "name": "Chair",
         "region": "Break Room",
         "original_item": "Fuse - Main Hall",
+        "force_item": "Combat Knife",
         "condition": {},    
         "item_object": "sm73_723",
         "parent_object": "sm73_723_fuse2",
@@ -1610,8 +1611,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "Rook_sm42_215_PlugPlace02A_control",
-        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
+        "item_object": "Knight_sm42_215_PlugPlace02A_control",
+        "parent_object": "Knight_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1619,8 +1620,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "King_sm42_215_PlugPlace02A_control",
-        "parent_object": "King_sm42_215_PlugPlace02A_control",
+        "item_object": "Bishop_sm42_215_PlugPlace02A_control",
+        "parent_object": "Bishop_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -7,7 +7,7 @@
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Main Desk",
@@ -17,7 +17,7 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Marvin's Knife",
@@ -37,7 +37,7 @@
         "item_object": "sm42_176_HieroglyphicDialLock01A_ForLion_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0000/Hall/LionStatue",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "2F Couch",
@@ -47,7 +47,7 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100_HandgunB",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Hall",
-        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
+        "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters", "Combat Knife"]
     },
     {
         "name": "Shelves",

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -1147,6 +1147,7 @@
         "name": "Chair",
         "region": "Break Room",
         "original_item": "Fuse - Main Hall",
+        "force_item": "Combat Knife",
         "condition": {},    
         "item_object": "sm73_723",
         "parent_object": "sm73_723_fuse2",
@@ -1589,8 +1590,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "Rook_sm42_215_PlugPlace02A_control",
-        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
+        "item_object": "Knight_sm42_215_PlugPlace02A_control",
+        "parent_object": "Knight_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1598,8 +1599,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "King_sm42_215_PlugPlace02A_control",
-        "parent_object": "King_sm42_215_PlugPlace02A_control",
+        "item_object": "Bishop_sm42_215_PlugPlace02A_control",
+        "parent_object": "Bishop_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {


### PR DESCRIPTION
In B scenarios only, the name of the panels that hold the Knight and Bishop plugs are different, which prevented sending the items on these locations. This PR updates those names.

(Also, this PR brings in the recent knife updates from the apworld side.)