### PR TITLE
Add warnings about typewriter misuse, and a hint about Insert to hide REF windows

### DIFF
--- a/reframework/autorun/randomizer/Tools.lua
+++ b/reframework/autorun/randomizer/Tools.lua
@@ -39,7 +39,7 @@ function Tools.ShowGUI()
     -- if Scene.isCharacterClaire() then player_character_text = "   Claire" end
     -- if Scene.isCharacterSherry() then player_character_text = "   Sherry" end
 
-    imgui.set_next_window_size(Vector2f.new(200, 620), 0)
+    imgui.set_next_window_size(Vector2f.new(200, 720), 0)
     imgui.begin_window("Archipelago Game Mod ", nil,
         8 -- NoScrollbar
     )
@@ -59,9 +59,14 @@ function Tools.ShowGUI()
     imgui.text_colored("DeathLink:   ", -10825765)
     imgui.text_colored(deathlink_text, deathlink_color)
     imgui.new_line()
-    -- imgui.text_colored("Current Player Character:   ", -10825765)
-    -- imgui.text(player_character_text)
-    -- imgui.new_line()
+
+    imgui.separator()
+    imgui.text(" The default keyboard key to")
+    imgui.text(" show or hide these windows is")
+    imgui.text(" INSERT.")
+    imgui.separator()
+
+    imgui.new_line()
     imgui.text_colored("Credits:", -10825765)
     imgui.text("@Fuzzy")
     imgui.text("   - Mod Dev, Leon A")

--- a/reframework/autorun/randomizer/Typewriters.lua
+++ b/reframework/autorun/randomizer/Typewriters.lua
@@ -88,6 +88,8 @@ function Typewriters.DisplayWarpMenu()
         imgui.push_font(font)
     end
 
+    imgui.text_colored("Use typewriter teleports to visit areas that you previously visited. If you skip ahead, YOU MIGHT SOFTLOCK.", AP_REF.HexToImguiColor("AAAAAA"))
+
     for t, typewriter in pairs(Lookups.typewriters) do
         local typewriter_disabled = false
 
@@ -129,6 +131,8 @@ function Typewriters.DisplayWarpMenu()
 
     imgui.new_line()
     imgui.new_line()
+
+    imgui.text_colored("This button is here in case you missed a typewriter in an area you passed through. You should rarely need to use this.", AP_REF.HexToImguiColor("AAAAAA"))
 
     if imgui.button("Unlock All Typewriter Teleports") then
         Typewriters.UnlockAll()


### PR DESCRIPTION
There's been an increase in the number of people that have gotten themselves softlocked with typewriter teleports and can't find the keyboard key to hide windows in the pins in Discord, so this PR explains both in the in-game windows.