### PR TITLE
Enemy fixes

### DIFF
--- a/reframework/autorun/randomizer/Manifest.lua
+++ b/reframework/autorun/randomizer/Manifest.lua
@@ -1,6 +1,6 @@
 local Manifest = {}
 
 Manifest.mod_name = "ArchipelagoRE2R"
-Manifest.version = "0.3.3"
+Manifest.version = "0.3.4"
 
 return Manifest

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -1,14 +1,14 @@
 [
     {
-            "name": "Police Zombie at Elliot",
+            "name": "Police Zombie after Elliot",
             "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1stDoorBan",
-            "parent_object": "16-239-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"item_object": "emZombie_1stDoorBan",
+			"parent_object": "16-239-0-0-ID213",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window",
@@ -32,7 +32,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie in Closet",
+            "name": "Overweight Zombie",
             "region": "East Hallway 1F Closet",
             "original_item": "",
             "item_object": "emZombie_DepotLate",
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie from Operations Room Window",
+            "name": "First Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW2Window",
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "First Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window",
@@ -88,15 +88,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of Stairs",
-            "region": "West Hallway 3F",
+            "name": "Roaming Zombie on West Stairwell",
+            "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
             "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of Stairs",
+            "name": "Police Zombie sitting at top of Stairs",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -104,7 +104,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -112,10 +112,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Battery", "Electronic Gadget"]
-            }
+			}
     },
     {
-            "name": "Female Zombie near Spade Door",
+            "name": "Female Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library_4",
@@ -123,7 +123,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -131,7 +131,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie-Eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -139,28 +139,136 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
+            "name": "First Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+			"parent_object": "16-255-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Second Zombie from Window",
+			"region": "East Hallway 1F",
+			"original_item": "",
+			"item_object": "emZombie1FE2Window2nd",
+			"parent_object": "16-239-0-0-ID003",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Wandering Zombie",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice2",
+			"parent_object": "16-230-0-0-ID203",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
+	{
+			"name": "First Zombie from Window",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice_Window",
+			"parent_object": "16-230-0-0-ID207",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
+	{
+			"name": "First Zombie from South Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW4Window",
+			"parent_object": "16-125-0-0-ID211",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Roaming Jumpsuit Zombie",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window_Add",
+			"parent_object": "16-225-0-0-ID008",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "First Zombie from Center Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW_Knock",
+			"parent_object": "16-225-0-1-ID003",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Roaming High Visibility Zombie",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FWAdd",
+			"parent_object": "16-225-0-2-ID004",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Second Zombie from North Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window_BreakIn",
+			"parent_object": "16-225-0-1-ID012",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},	
     {
-            "name": "Helicopter Crash Zombie 2",
-            "region": "East Hallway 2F",
+			"name": "Second Zombie from Window",
+			"region": "West Hallway 1F",
+			"original_item": "",
+			"item_object": "emZombie1FW1Window2nd",
+			"parent_object": "16-226-0-0-ID014",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
+    {
+            "name": "Licker outside STARS Office",
+            "region": "STARS Office",
             "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "item_object": "FirstLicker",
+            "parent_object": "16-253-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Maiden Medallion"]
+            }
     },
     {
-            "name": "2nd Zombie at Stairs",
-            "region": "West Hallway 1F",
+            "name": "Licker that loves explosions",
+            "region": "West Storage Room",
             "original_item": "",
-            "item_object": "emZombie1FW1Window2nd",
-            "parent_object": "16-226-0-0-ID014",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "item_object": "emLicker_3FLickerRoomA",
+            "parent_object": "16-265-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Battery", "Electronic Gadget"]
+            },
+            "excluded": 1
     },
     {
             "type": "Boss",
@@ -168,7 +276,7 @@
             "region": "Machinery Room",
             "original_item": "",
             "item_object": "G1",
-            "parent_object": "29-353-1-12-nil",
+            "parent_object": "29-353-0-12-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -188,15 +296,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker outside of Kennel Room",
+            "name": "Licker on far wall",
             "region": "Kennel",
             "original_item": "",
-            "item_object": "Riccer_04",
+            "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker eating zombie dog",
+            "name": "Licker eating Zombie Dog",
             "region": "Kennel",
             "original_item": "",
             "item_object": "Riccer_03",
@@ -212,7 +320,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at Door",
+            "name": "Zombie sitting behind Door",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
@@ -220,7 +328,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
@@ -230,28 +338,17 @@
                 "items": ["Diamond Key"]
             }
     },
-    {
-            "name": "Bald Police Zombie",
-            "region": "Observation Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FE1Window",
-            "parent_object": "16-240-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+	{
+			"name": "Licker on ceiling",
+			"region": "Kennel",
+			"original_item": "",
+			"item_object": "Riccer_04",
+			"parent_object": "29-272-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Diamond Key"]
             }
-    },
-    {
-            "name": "Interrogation Room Licker",
-            "region": "Interrogation Room",
-            "original_item": "",
-            "item_object": "1FEInterrogationRoom_Licker",
-            "parent_object": "16-233-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+	},
     {
             "name": "Dark Police Zombie",
             "region": "East Storage Room",
@@ -281,21 +378,111 @@
             }
     },
     {
-            "name": "Female Zombie outside of Boiler Room",
-            "region": "Roof",
+            "name": "Bald Police Zombie from Window",
+            "region": "Observation Room Hallway",
             "original_item": "",
-            "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-1-ID002",
+            "item_object": "emZombie1FE1Window",
+            "parent_object": "16-240-0-0-ID213",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+            "name": "Jump Scare Licker",
+            "region": "Interrogation Room",
+            "original_item": "",
+            "item_object": "1FEInterrogationRoom_Licker",
+            "parent_object": "16-233-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Male Zombie outside of Boiler Room",
-            "region": "Roof",
+			"name": "Second Zombie from South Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW4Window3rd",
+			"parent_object": "16-125-0-0-ID012",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+			"name": "Second Zombie from Center Window",   
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window3rd",
+			"parent_object": "16-225-0-0-ID011",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+            "name": "Licker outside West Office",
+            "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-431-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
     },
+    {
+			"name": "Licker in blocked passage",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emLicker_1FW2-2",
+			"parent_object": "16-125-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack 	Handle"]
+				]
+			}
+	},
+	{
+			"name": "Licker",
+			"region": "West Storage Room",
+			"original_item": "",
+			"item_object": "emLicker_3FW2-2",
+			"parent_object": "16-265-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
     {
             "name": "Zombie Marvin",
             "region": "Main Hall",
@@ -311,18 +498,20 @@
             }
     },
     {
-            "name": "Licker outside West Office",
-            "region": "West Hallway 1F",
+            "name": "Female Zombie outside of Boiler Room",
+            "region": "Roof",
             "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-431-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
+            "item_object": "emZombie_OutdoorNorth",
+            "parent_object": "16-122-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Male Zombie outside of Boiler Room",
+            "region": "Roof",
+            "original_item": "",
+            "item_object": "emZombie_OutdoorNorth",
+            "parent_object": "16-122-0-0-ID004",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "Plain Clothes Zombie",
@@ -349,6 +538,34 @@
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+			"name": "Second Zombie from Window",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice_Window",
+			"parent_object": "16-230-0-0-ID007",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+            "name": "Third Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FEWindow3rd",
+            "parent_object": "16-239-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
     },
@@ -431,151 +648,6 @@
             "item_object": "em4000_Last_01",
             "parent_object": "25-408-0-4-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Female Zombie from window",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FEWindow3rd",
-            "parent_object": "16-239-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-    {
-            "name": "Plaid Shirt Zombie",
-            "region": "Press Room",
-            "original_item": "",
-            "item_object": "emZombie_1FECorriderB",
-            "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Film - Hiding Place"]
-            }
-    },
-    {
-            "name": "Jumpsuit Zombie from office or window",
-            "region": "East Office",
-            "original_item": "",
-            "item_object": "emZombie_1FEOffice_Window",
-            "parent_object": "16-230-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-        {
-            "name": "Plain Clothes Zombie from first Window",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW4Window3rd",
-            "parent_object": "16-125-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-        {
-            "name": "Jumpsuit Zombie",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window_Add",
-            "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Maiden Medallion"]
-            }
-    },
-        {
-            "name": "Plain Clothes Zombie from mid Window",   
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window3rd",
-            "parent_object": "16-225-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-       {
-            "name": "2nd Blonde Zombie from Operations Room Window",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window_BreakIn",
-            "parent_object": "16-225-0-1-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-       {
-            "name": "Overweight Zombie wearing Vest",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FWAdd",
-            "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Maiden Medallion"]
-            }
-    },
-        {
-            "name": "Licker at start of hallway",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-125-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-    {
-            "name": "Licker outside STARS Office",
-            "region": "STARS Office",
-            "original_item": "",
-            "item_object": "FirstLicker",
-            "parent_object": "16-253-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-       {
-            "name": "Licker outside West Storage Room",
-            "region": "West Hallway 3F",
-            "original_item": "",
-            "item_object": "emLicker_3FW2-2",
-            "parent_object": "16-265-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-        {
-            "name": "Licker near Maiden Statue",
-            "region": "West Storage Room",
-            "original_item": "",
-            "item_object": "emLicker_3FLickerRoomA",
-            "parent_object": "16-265-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Battery", "Electronic Gadget"]
-            },
-            "excluded": 1
     },
     {
             "name": "Zombie by Lockers",
@@ -783,7 +855,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie in bed",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -810,7 +882,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -818,22 +890,22 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
             "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
-            "name": "Ivy the Fourth",
+    {
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
             "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-       {
+    {
             "name": "Short Hair Lab Coat Zombie",
             "region": "Lounge - Labs",
             "original_item": "",
@@ -909,20 +981,26 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
         {
-            "name": "First Ivy near basement ladder",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
         {
-            "name": "Ivy No. 5",
+            "name": "Second Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "name": "Surprise Ivy leaving Greenhouse",
@@ -932,7 +1010,7 @@
             "parent_object": "3-433-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "type": "Boss",
             "name": "G3 Boss Fight",
             "region": "Bioreactors Room",
@@ -941,7 +1019,7 @@
             "parent_object": "3-419-0-15-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "name": "Ivy 1 after elevator",
             "region": "Path to G4",
             "original_item": "",
@@ -973,7 +1051,7 @@
             "parent_object": "21-135-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "name": "That Random Escape Zombie",
             "region": "Path to G4",
             "original_item": "",

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -1011,7 +1011,10 @@
             "original_item": "",
             "item_object": "IvyZombie_Idle",
             "parent_object": "3-433-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["ID Wristband - Senior Staff"]
+            }
     },
     {
             "type": "Boss",

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -359,7 +359,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -373,7 +373,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -387,7 +387,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -400,8 +400,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -423,7 +423,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -437,7 +437,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -451,7 +451,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -464,8 +464,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -479,7 +479,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -493,7 +493,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -521,10 +521,7 @@
             "parent_object": "16-112-0-0-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Mechanic Jack Handle"]
             }
     },
     {
@@ -535,10 +532,7 @@
             "parent_object": "16-112-0-0-ID200",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Mechanic Jack Handle"]
             }
     },
     {
@@ -551,7 +545,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -564,8 +558,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -593,6 +587,14 @@
             "parent_object": "25-408-0-1-ID000",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Zombie Dog behind fence",
+			"region": "RPD Streets",
+			"original_item": "",
+			"item_object": "em4000_Fence_01",
+			"parent_object": "25-408-0-4-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
     {
             "name": "Action Dog on white car",
             "region": "RPD Streets",
@@ -1035,6 +1037,14 @@
             "parent_object": "21-134-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Ivy 3 after elevator",
+			"region": "Path to G4",
+			"original_item": "",
+			"item_object": "Ivy_03",
+			"parent_object": "21-134-0-7-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
     {
             "name": "Falling Ivy 1",
             "region": "Path to G4",

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -14,7 +14,8 @@
             "item_object": "emZombie1FE2Window",
             "parent_object": "16-239-0-0-ID017",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+			},
+            "excluded": 1
     {
             "name": "Blonde Zombie",
             "region": "East Hallway 1F",
@@ -46,6 +47,7 @@
             "item_object": "emZombie1FW2Window",
             "parent_object": "16-225-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Overweight Zombie at Vending Machines",
@@ -86,6 +88,7 @@
             "item_object": "emZombie1FW1Window",
             "parent_object": "16-226-0-0-ID016",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Roaming Zombie on West Stairwell",
@@ -145,6 +148,7 @@
             "item_object": "emZombie_2FECorrider",
 			"parent_object": "16-255-0-0-ID012",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -153,6 +157,7 @@
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
 	{
 			"name": "Second Zombie from Window",
@@ -163,7 +168,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Wandering Zombie",
@@ -172,6 +178,7 @@
 			"item_object": "emZombie_1FEOffice2",
 			"parent_object": "16-230-0-0-ID203",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
 	},
 	{
 			"name": "First Zombie from Window",
@@ -180,6 +187,7 @@
 			"item_object": "emZombie_1FEOffice_Window",
 			"parent_object": "16-230-0-0-ID207",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
 	},
 	{
 			"name": "First Zombie from South Window",
@@ -190,7 +198,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Roaming Jumpsuit Zombie",
@@ -212,7 +221,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Roaming High Visibility Zombie",
@@ -348,7 +358,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Diamond Key"]
-            }
+            },
+			"excluded": 1
 	},
     {
             "name": "Dark Police Zombie",

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -464,8 +464,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": [
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack 	Handle"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
 				]
 			}
 	},

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -301,7 +301,8 @@
             "original_item": "",
             "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Licker eating Zombie Dog",

--- a/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/a/enemies.json
@@ -1075,6 +1075,9 @@
             "original_item": "",
             "item_object": "G4",
             "parent_object": "21-421-0-16-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -53,7 +53,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -61,7 +62,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Standing Police Zombie",
@@ -69,7 +71,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Dark-Haired Zombie",
@@ -197,7 +200,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -205,7 +209,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Cop in the South Side of the Hallway",

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -586,7 +586,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall", "Diamond Key"]
             }
     },
     {

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -266,7 +266,8 @@
             "original_item": "",
             "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Licker eating Dog",

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -1156,7 +1156,10 @@
             "original_item": "",
             "item_object": "G4",
             "parent_object": "21-421-0-16-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -326,7 +326,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },	
@@ -339,7 +339,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },
@@ -352,7 +352,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },
@@ -365,7 +365,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },	
@@ -586,7 +586,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall"]
             }
     },
     {
@@ -1157,10 +1157,7 @@
             "original_item": "",
             "item_object": "G4",
             "parent_object": "21-421-0-16-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Joint Plug"]
-            }
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "type": "Boss",
@@ -1169,6 +1166,9 @@
             "original_item": "",
             "item_object": "G5",
             "parent_object": "21-423-0-17-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -97,7 +97,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway 1F",
+            "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW",
             "parent_object": "16-125-0-3-nil",
@@ -139,7 +139,7 @@
             "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1FW1Window2nd",
+            "item_object": "emZombie1FW1Window2nd",
             "parent_object": "16-226-0-0-ID014",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
@@ -156,7 +156,7 @@
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
-            "parent_object": "16-253-0-0-ID200",
+            "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -208,10 +208,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Zombie from South Window",
+            "name": "Cop in the South Side of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW4Window",
+            "item_object": "emZombie1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -219,10 +219,10 @@
             }
     },
     {
-            "name": "First Zombie from Center Window",
+            "name": "Jumpsuit Zombie in the Center of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW3Window",
+            "item_object": "emZombie1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -233,7 +233,7 @@
             "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FWAdd",
+            "item_object": "emZombie1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -305,7 +305,7 @@
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
-            "parent_object": "29-273-0-2-ID004",
+            "parent_object": "29-273-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -480,7 +480,7 @@
             "region": "Roof",
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-1-ID004",
+            "parent_object": "16-122-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 		        "items": [
@@ -493,7 +493,7 @@
             "region": "Roof",
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-0-ID002",
+            "parent_object": "16-122-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 				"items": [
@@ -515,7 +515,7 @@
             }
     },
     {
-            "name": "Second Zombie from South Window",
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -528,10 +528,10 @@
             }
     },
     {
-            "name": "Second Zombie from Center Window",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombieFW3Window3rd",
+            "item_object": "emZombie1FW3Window3rd",
             "parent_object": "16-225-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -542,7 +542,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emLicker_1FW2-2",
             "parent_object": "16-431-0-3-nil",
@@ -637,7 +637,8 @@
             "original_item": "",
             "item_object": "em0100_Start_01",
             "parent_object": "25-408-0-1-ID000",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog on White Car",
@@ -847,7 +848,7 @@
             "region": "Supplies Storage Room",
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
-            "parent_object": "17-327-0-0-ID008",
+            "parent_object": "17-327-0-2-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -1053,7 +1054,8 @@
             "original_item": "",
             "item_object": "ZombieTAreaLowTemperature",
             "parent_object": "3-414-0-1-ID304",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Lab Coat Zombie at bottom of stairs",

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Elliot",
+            "name": "Elliot is half the man he used to be",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FEEliot",
@@ -48,7 +48,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "2nd Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Marvin",
+            "name": "Marvin is just pranking us, right?",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_2ndMarvin",
@@ -88,7 +88,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie East Rail",
+            "name": "Female Zombie Upstairs",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_1FECorridor_DepotZombies",
@@ -128,7 +128,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -136,7 +136,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW1Window2nd",
@@ -144,7 +144,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of stairs",
+            "name": "Police Zombie that loves Jumping",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -152,7 +152,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at end of corridor",
+            "name": "Zombie between floors",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
@@ -160,7 +160,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of stairs",
+            "name": "Surprise Zombie from Spade Key room",
             "region": "West Hallway 3F",
             "original_item": "",
             "item_object": "2ndPlaySpadekeyZombie",
@@ -176,7 +176,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -184,7 +184,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Key Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -192,15 +192,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Helicopter Crash Zombie 2",
+            "name": "First Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -208,28 +200,45 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first window",
+            "name": "Second Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+            "parent_object": "16-255-0-0-ID216",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
             "type": "Boss",
@@ -237,41 +246,44 @@
             "region": "Machinery Room",
             "original_item": "",
             "item_object": "G1",
-            "parent_object": "29-353-1-12-nil",
+            "parent_object": "29-353-0-12-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-	{
-			"name": "Licker on Ceiling",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_04",
-			"parent_object": "29-272-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Licker at end of Hallway",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_01",
-			"parent_object": "29-272-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Licker eating Dog",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_03",
-			"parent_object": "29-279-0-3-nil",
+    {
+		    "name": "Licker on Ceiling",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_04",
+            "parent_object": "29-272-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Diamond Key"]
+            }
+    },
+    {
+            "name": "Licker at end of Hallway",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_01",
+            "parent_object": "29-272-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Licker behind cages",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_02",
-			"parent_object": "29-279-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    },
+    {
+            "name": "Licker eating Dog",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_03",
+            "parent_object": "29-279-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Licker behind cages",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_02",
+            "parent_object": "29-279-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "Overweight Zombie",
             "region": "Firing Range",
@@ -302,9 +314,84 @@
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
             "parent_object": "29-273-0-0-ID008",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dark Police Zombie from Window",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC_Window",
+            "parent_object": "16-229-0-0-ID207",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Diamond Key"]
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Dark Police Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID209",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Plaid Shirt Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Munching Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID208",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Second Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FEWindow3rd",
+            "parent_object": "16-239-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
             }
     },
     {
@@ -317,7 +404,7 @@
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             }
-    },
+    },	
     {
             "name": "Police Zombie",
             "region": "Main Hall 3F",
@@ -330,6 +417,19 @@
             }
     },
     {
+            "name": "Second Zombie from Window",
+            "region": "East Office",
+            "original_item": "",
+            "item_object": "emZombie_1FEOffice_Window",
+            "parent_object": "16-230-0-0-ID007",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
             "name": "Short-Haired Police Zombie",
             "region": "East Storage Room",
             "original_item": "",
@@ -337,7 +437,7 @@
             "parent_object": "16-269-0-0-ID214",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             }
     },
     {
@@ -348,18 +448,31 @@
             "parent_object": "16-269-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             }
     },
     {
-            "name": "Police Zombie through window",
+            "name": "Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
             "parent_object": "16-240-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
+				"items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Interrogator Licker",
+            "region": "Interrogation Room",
+            "original_item": "",
+            "item_object": "1FEInterrogationRoom_Licker",
+            "parent_object": "16-233-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
             }
     },
     {
@@ -368,7 +481,12 @@
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-1-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+		        "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
     },
     {
             "name": "Female Zombie outside Boiler Room",
@@ -376,22 +494,80 @@
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-0-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-	{
-			"name": "Licker at Maiden Statue",
-			"region": "West Storage Room",
-			"original_item": "",
-			"item_object": "emLicker_3FW2-2",
-			"parent_object": "16-265-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Battery", "Electronic Gadget"]
-            },
-            "excluded": 1
-	},
+				"items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
+    },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Second Licker",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-125-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Second Zombie from South Window",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombie1FW4Window3rd",
+            "parent_object": "16-125-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Second Zombie from Center Window",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombieFW3Window3rd",
+            "parent_object": "16-225-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Licker",
+            "region": "West Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-431-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Licker",
+            "region": "West Storage Room",
+            "original_item": "",
+            "item_object": "emLicker_3FW2-2",
+            "parent_object": "16-265-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+              }
+    },
+    {
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -402,136 +578,147 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
             }
     },
-	{
-			"name": "Zombie banging on gate",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Fence_Door",
-			"parent_object": "25-406-0-0-ID305",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Zombie with plaid shirt",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Fence_01",
-			"parent_object": "25-406-0-0-ID014",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Misty by the dumpster",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Start_01",
-			"parent_object": "25-408-0-1-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Zombie Dog behind fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Fence_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Second Dog behind Fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Start_01",
-			"parent_object": "25-408-0-1-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog on White Car",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Start_02",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog having a snack",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Eat_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog 1 jumping fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog 2 jumping fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_02",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog before bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_03",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Another one rides the bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0000_Bus_02",
-			"parent_object": "25-408-0-0-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog after bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Last_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Short hair zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_03",
-			"parent_object": "17-330-0-0-ID019",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Overweight zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_05",
-			"parent_object": "17-330-0-2-ID002",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Shorter hair zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_04",
-			"parent_object": "17-330-2-0-ID020",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    {
+            "name": "Skylight Licker",
+            "region": "Art Room",
+            "original_item": "",
+            "item_object": "emLicker_2FEArtRoomLicker",
+            "parent_object": "16-256-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Red Book", "Statue Left Arm"]
+            }
+    },
+    {
+            "name": "Zombie banging on gate",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Fence_Door",
+            "parent_object": "25-406-0-0-ID305",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Zombie with plaid shirt",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Fence_01",
+            "parent_object": "25-406-0-0-ID014",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Misty by the dumpster",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Start_01",
+            "parent_object": "25-408-0-1-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Zombie Dog behind fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Fence_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Dog behind Fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Start_01",
+            "parent_object": "25-408-0-1-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog on White Car",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Start_02",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog having a snack",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Eat_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog 1 jumping fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog 2 jumping fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_02",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog before bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_03",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Another one rides the bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0000_Bus_02",
+            "parent_object": "25-408-0-0-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog after bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Last_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Short hair zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_03",
+            "parent_object": "17-330-0-0-ID019",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Overweight zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_05",
+            "parent_object": "17-330-0-2-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Shorter hair zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_04",
+            "parent_object": "17-330-2-0-ID020",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "Blue Jumpsuit Zombie",
             "region": "Waterway Overpass",
@@ -605,8 +792,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["T-Bar Handle"]
-            },
-            "excluded": 1
+            }
     },
     {
             "name": "Downed Plain Zombie",
@@ -633,7 +819,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Third G-Adult from sewer hole",
+            "name": "Third G-Adult from Sewer Pipe",
             "region": "Bottom Waterway",
             "original_item": "",
             "item_object": "em6000_Hole",
@@ -646,135 +832,6 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
             "parent_object": "17-325-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-	{
-			"name": "G-Adult upper waterway",
-			"region": "Upper Waterway",
-			"original_item": "",
-			"item_object": "em6000_07",
-			"parent_object": "17-315-0-8-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "West Hallway Licker",
-			"region": "West Hallway",
-			"original_item": "",
-			"item_object": "emLicker_1FW2-2",
-			"parent_object": "16-431-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Skylight Licker",
-			"region": "Art Room",
-			"original_item": "",
-			"item_object": "emLicker_2FEArtRoomLicker",
-			"parent_object": "16-256-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Peeping Tom-bie",
-			"region": "Press Room",
-			"original_item": "",
-			"item_object": "emZombie_1FECorriderB",
-			"parent_object": "16-232-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Interrogator Licker",
-			"region": "Interrogation Room",
-			"original_item": "",
-			"item_object": "1FEInterrogationRoom_Licker",
-			"parent_object": "16-233-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Southwest Hallway Licker 2",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emLicker_1FW2-2",
-			"parent_object": "16-125-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Southwest Hallway 3rd Window Zombie",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emZombieFW3Window3rd",
-			"parent_object": "16-225-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Southwest Hallway 1st Window Zombie",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emZombie1FW4Window3rd",
-			"parent_object": "16-125-0-0-ID012",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Overalls Zombie East Office Window",
-			"region": "East Office",
-			"original_item": "",
-			"item_object": "emZombie_1FEOffice_Window",
-			"parent_object": "16-230-0-0-ID007",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Female Zombie through window by East Office",
-			"region": "East Hallway 1F",
-			"original_item": "",
-			"item_object": "emZombie1FEWindow3rd",
-			"parent_object": "16-239-0-1-ID002",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "conditions": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-	},
-	{
-			"name": "Dark Clothes Zombie East Hallway",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID209",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Plaid Shirt Zombie East Hallway",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Snacking Zombie",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID208",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dark Clothes Zombie from Window",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC_Window",
-			"parent_object": "16-229-0-0-ID207",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-            }
-	},
-    {
-            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
-            "region": "Bottom Waterway",
-            "original_item": "",
-            "item_object": "Zombie_WasteGAdultArea_man01",
-            "parent_object": "17-325-0-0-ID024",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -799,6 +856,22 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
+            "region": "Bottom Waterway",
+            "original_item": "",
+            "item_object": "Zombie_WasteGAdultArea_man01",
+            "parent_object": "17-325-0-0-ID024",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "G-Adult upper waterway",
+            "region": "Upper Waterway",
+            "original_item": "",
+            "item_object": "em6000_07",
+            "parent_object": "17-315-0-8-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -851,7 +924,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dr Li",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -878,15 +951,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_AfterFall",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },    
-    {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -894,7 +959,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
@@ -902,7 +967,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy the Fourth",
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
@@ -910,20 +975,37 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy No. 5",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
+    },   
+    {
+            "name": "Second Ivy after using Dispersal Cartridge",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_AfterFall",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
 	{
-			"name": "Ivy in Disperal Room",
-			"region": "Greenhouse Control Room",
-			"original_item": "",
-			"item_object": "IvyZombie_Idle",
-			"parent_object": "3-433-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "name": "Surprise Ivy",
+            "region": "Greenhouse Control Room",
+            "original_item": "",
+            "item_object": "IvyZombie_Idle",
+            "parent_object": "3-433-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["ID Wristband - Senior Staff"]
+            }
 	},
     {
             "name": "Short Hair Lab Coat Zombie",
@@ -1041,22 +1123,22 @@
             "parent_object": "21-134-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-	{
-			"name": "Ivy Air Drop",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "IvyZombie01",
-			"parent_object": "21-135-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Ivy Air Drop 2",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "IvyZombie02",
-			"parent_object": "21-135-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    {
+            "name": "First Ivy Air Drop",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "IvyZombie01",
+            "parent_object": "21-135-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Ivy Air Drop",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "IvyZombie02",
+            "parent_object": "21-135-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "That Random Escape Zombie but on fire",
             "region": "Path to G4",
@@ -1067,12 +1149,12 @@
     },
     {
             "type": "Boss",
-			"name": "G4",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "G4",
-			"parent_object": "21-421-0-16-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "name": "G4 Boss Fight",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "G4",
+            "parent_object": "21-421-0-16-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "type": "Boss",

--- a/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/enemies.json
@@ -129,7 +129,7 @@
     },
     {
             "name": "Police Zombie Playing Dead",
-            "region": "East Hallway 1F",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
             "parent_object": "16-431-0-0-ID213",

--- a/reframework/data/ArchipelagoRE2R/claire/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/locations.json
@@ -150,7 +150,9 @@
         "region": "Press Room",
         "original_item": "Needle Cartridges",
         "condition": {
-            "items": ["Fuse - Main Hall", "Film - Hiding Place"]
+            "items": [
+			["Fuse - Main Hall", "Film - Hiding Place"], ["Spade Key", "Film - Hiding Place"]
+			]
         },    
         "item_object": "sm70_109",
         "parent_object": "ItemPos_TreasureA_Claire",

--- a/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/claire/b/region_connections.json
@@ -192,13 +192,13 @@
         }
     },
     { 
-        "from": "Main Hall",
-        "to": "Waiting Room",
+        "from": "Waiting Room",
+        "to": "Main Hall",
         "condition": {}
     },
     { 
-        "from": "Waiting Room",
-        "to": "East Hallway 2F",
+        "from": "East Hallway 2F",
+        "to": "Waiting Room",
         "condition": {
             "items": ["Spade Key"]
         }

--- a/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
@@ -13,7 +13,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window",
             "parent_object": "16-239-0-0-ID017",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Blonde Zombie",
@@ -45,7 +46,8 @@
             "original_item": "",
             "item_object": "emZombie1FW2Window",
             "parent_object": "16-225-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Overweight Zombie at Vending Machines",
@@ -85,7 +87,8 @@
             "original_item": "",
             "item_object": "emZombie1FW1Window",
             "parent_object": "16-226-0-0-ID016",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Roaming Zombie on West Stairwell",
@@ -144,7 +147,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
 			"parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -152,7 +156,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Zombie from Window",
@@ -163,7 +168,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			      "condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
     },
     {
             "name": "Wandering Zombie",
@@ -171,7 +177,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -179,7 +186,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from South Window",   
@@ -190,7 +198,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Maiden Medallion"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Roaming Jumpsuit Zombie",
@@ -212,7 +221,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Maiden Medallion"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Roaming High Visibility Zombie",
@@ -344,7 +354,8 @@
             "original_item": "",
             "item_object": "FenceClimbDog",
             "parent_object": "29-274-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog under fence outside door",
@@ -352,7 +363,8 @@
             "original_item": "",
             "item_object": "dog_East_twinsBlue1",
             "parent_object": "29-272-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -363,7 +375,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog from vent",
@@ -374,7 +387,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Dark Police Zombie",

--- a/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
@@ -1,10 +1,18 @@
 [
     {
-            "name": "Dark-Haired Zombie",
+            "name": "Police Zombie after Elliot",
             "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_Depot1",
-            "parent_object": "16-239-0-0-ID006",
+            "item_object": "emZombie_1stDoorBan",
+            "parent_object": "16-239-0-0-ID213",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FE2Window",
+            "parent_object": "16-239-0-0-ID017",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -16,7 +24,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie in Closet",
+            "name": "Dark-Haired Zombie",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie_Depot1",
+            "parent_object": "16-239-0-0-ID006",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Overweight Zombie",
             "region": "East Hallway 1F Closet",
             "original_item": "",
             "item_object": "emZombie_DepotLate",
@@ -24,42 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Elliot's Window",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FE2Window",
-            "parent_object": "16-239-0-0-ID017",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "2nd Zombie from Elliot's Window",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FE2Window2nd",
-            "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Police Zombie at Elliot",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie_1stDoorBan",
-            "parent_object": "16-239-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Plaid Shirt Zombie",
-            "region": "Press Room",
-            "original_item": "",
-            "item_object": "emZombie_1FECorriderB",
-            "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Film - Hiding Place"]
-            }
-    },
-    {
-            "name": "Female Zombie from Operations Room Window",
+            "name": "First Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW2Window",
@@ -72,6 +53,14 @@
             "original_item": "",
             "item_object": "emZombie_1FWjihanki",
             "parent_object": "16-431-0-2-ID200",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Police Zombie Playing Dead",
+            "region": "West Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie_1FW_TrapZombie",
+            "parent_object": "16-431-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -91,15 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
-            "region": "West Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie_1FW_TrapZombie",
-            "parent_object": "16-431-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Zombie from Window at Stairs",
+            "name": "First Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window",
@@ -107,8 +88,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of Stairs",
-            "region": "West Hallway 3F",
+            "name": "Roaming Zombie on West Stairwell",
+            "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
             "parent_object": "16-226-1-0-ID009",
@@ -123,7 +104,18 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie near Spade Door",
+            "name": "Zombie Hanging Around",
+            "region": "West Storage Room",
+            "original_item": "",
+            "item_object": "DeadZombie",
+            "parent_object": "16-265-0-0-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Battery", "Electronic Gadget"]
+            }
+    },
+    {
+            "name": "Female Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library_4",
@@ -131,7 +123,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -139,7 +131,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie-Eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -147,7 +139,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
+            "name": "First Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+			"parent_object": "16-255-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -155,15 +155,18 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 2",
-            "region": "East Hallway 2F",
+            "name": "Second Zombie from Window",
+            "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "item_object": "emZombie1FE2Window2nd",
+            "parent_object": "16-239-0-0-ID003",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			      "condition": {
+                "items": ["Maiden Medallion"]
+			}
     },
     {
-            "name": "Standing Police Zombie",
+            "name": "Wandering Zombie",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
@@ -171,7 +174,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -179,7 +182,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first Window",   
+            "name": "First Zombie from South Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window",
@@ -190,7 +193,7 @@
             }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "Roaming Jumpsuit Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window_Add",
@@ -201,7 +204,7 @@
             }
     },
     {
-            "name": "Female Zombie from mid Window",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW_Knock",
@@ -212,7 +215,7 @@
             }
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "Roaming High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FWAdd",
@@ -223,7 +226,7 @@
             }
     },
     {
-            "name": "2nd Blonde Zombie from Operations Room Window",
+            "name": "Second Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window_BreakIn",
@@ -234,7 +237,7 @@
             }
     },
     {
-            "name": "2nd Zombie at Stairs",
+            "name": "Second Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window2nd",
@@ -256,7 +259,7 @@
             }
     },
     {
-            "name": "Licker near Maiden Statue",
+            "name": "Licker that loves explosions",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FLickerRoomA",
@@ -266,17 +269,6 @@
                 "items": ["Battery", "Electronic Gadget"]
             },
             "excluded": 1
-    },
-    {
-            "name": "Hanging Zombie After It Drops",
-            "region": "West Storage Room",
-            "original_item": "",
-            "item_object": "DeadZombie",
-            "parent_object": "16-265-0-0-ID000",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Battery", "Electronic Gadget"]
-            }
     },
     {
             "type": "Boss",
@@ -304,7 +296,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 1",
+            "name": "First Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage03Leon",
@@ -312,7 +304,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 2",
+            "name": "Second Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage02Leon",
@@ -320,7 +312,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 3",
+            "name": "Third Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage01Leon",
@@ -328,7 +320,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at Door",
+            "name": "Zombie sitting behind Door",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
@@ -336,7 +328,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
@@ -442,7 +434,7 @@
             }
     },
     {
-            "name": "Bald Police Zombie",
+            "name": "Bald Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -453,7 +445,18 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from first Window",
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            }
+    },
+    {
+            "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -464,7 +467,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from mid Window",   
+            "name": "Second Zombie from Center Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window3rd",
@@ -486,7 +489,7 @@
             }
     },
     {
-            "name": "Licker at start of hallway",
+            "name": "Licker in blocked passage",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW2-2",
@@ -497,8 +500,8 @@
             }
     },
     {
-            "name": "Licker outside West Storage Room",
-            "region": "West Hallway 3F",
+            "name": "Licker",
+            "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FW2-2",
             "parent_object": "16-265-0-3-nil",
@@ -557,7 +560,7 @@
             }
     },
     {
-            "name": "Dark Police Zombie from window",
+            "name": "Dark Police Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
@@ -571,21 +574,18 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Boxed Electronic Part 1"]
             }
     },
     {
-            "name": "Jumpsuit Zombie from office or window",
+            "name": "Second Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -596,7 +596,7 @@
             }
     },
     {
-            "name": "Female Zombie from window",
+            "name": "Third Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FEWindow3rd",
@@ -647,7 +647,7 @@
             "parent_object": "17-429-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -658,7 +658,7 @@
             "parent_object": "17-429-0-1-ID006",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -669,7 +669,7 @@
             "parent_object": "17-429-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -846,7 +846,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie in bed",
+            "name": "Zombie outside Nap Room",
+            "region": "Nap Room",
+            "original_item": "",
+            "item_object": "ZombieNorth04",
+            "parent_object": "3-129-0-0-ID400",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -857,11 +865,43 @@
             }
     },
     {
-            "name": "Zombie outside Nap Room",
-            "region": "Nap Room",
+            "name": "First Ivy before puzzle",
+            "region": "Greenhouse Control Room",
             "original_item": "",
-            "item_object": "ZombieNorth04",
-            "parent_object": "3-129-0-0-ID400",
+            "item_object": "IvyZombie_First",
+            "parent_object": "3-411-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Ivy before puzzle",
+            "region": "Greenhouse Control Room",
+            "original_item": "",
+            "item_object": "IvyZombie_FirstHang",
+            "parent_object": "3-411-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Idle",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Fall2",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Third Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Fall1",
+            "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -921,30 +961,6 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Lab Coat Zombie",
-            "region": "Lobby Storage",
-            "original_item": "",
-            "item_object": "ZombieTArea01",
-            "parent_object": "3-413-0-1-ID302",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "First Ivy before puzzle",
-            "region": "Greenhouse Control Room",
-            "original_item": "",
-            "item_object": "IvyZombie_First",
-            "parent_object": "3-411-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Second Ivy before puzzle",
-            "region": "Greenhouse Control Room",
-            "original_item": "",
-            "item_object": "IvyZombie_FirstHang",
-            "parent_object": "3-411-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
             "name": "Ivy at the top of the stairs",
             "region": "Lobby Storage",
             "original_item": "",
@@ -956,44 +972,34 @@
             }
     },
     {
-            "name": "First Ivy near basement ladder",
+            "name": "Female Lab Coat Zombie",
+            "region": "Lobby Storage",
+            "original_item": "",
+            "item_object": "ZombieTArea01",
+            "parent_object": "3-413-0-1-ID302",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
-            "name": "Second Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Idle",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy in the middle",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Fall2",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy the Fourth",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Fall1",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy No. 5",
+            "name": "Second Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "type": "Boss",

--- a/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/enemies.json
@@ -1049,7 +1049,10 @@
             "original_item": "",
             "item_object": "NakedTyrant",
             "parent_object": "21-373-0-11-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 1",
@@ -1057,7 +1060,10 @@
             "original_item": "",
             "item_object": "EscpZombie05",
             "parent_object": "21-422-0-2-ID006",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 2",
@@ -1065,7 +1071,10 @@
             "original_item": "",
             "item_object": "EscpZombie03",
             "parent_object": "21-422-0-0-ID023",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 3",
@@ -1073,7 +1082,10 @@
             "original_item": "",
             "item_object": "EscpZombie06",
             "parent_object": "21-422-0-0-ID025",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 4",
@@ -1081,7 +1093,10 @@
             "original_item": "",
             "item_object": "EscpZombie02",
             "parent_object": "21-422-0-2-ID005",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 5",
@@ -1089,7 +1104,10 @@
             "original_item": "",
             "item_object": "EscpZombie04",
             "parent_object": "21-422-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 6",
@@ -1097,6 +1115,9 @@
             "original_item": "",
             "item_object": "EscpZombie01",
             "parent_object": "21-422-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/reframework/data/ArchipelagoRE2R/leon/a/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/locations.json
@@ -2393,7 +2393,9 @@
         "name": "Final Hit on Super Tyrant",
         "region": "Path to Super Tyrant",
         "original_item": "Anti-tank Rocket",
-        "condition": {},    
+        "condition": {
+            "items": ["Joint Plug"]
+        },
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",

--- a/reframework/data/ArchipelagoRE2R/leon/a/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/leon/a/region_connections.json
@@ -284,7 +284,7 @@
         "from": "Generator Room",
         "to": "Break Room Hallway",
         "condition": {
-            "items": ["Fuse - Break Room Hallway"]
+            "items": ["Square Crank"]
         }
     },
     { 
@@ -324,8 +324,8 @@
         "to": "Interrogation Room",
         "condition": {
             "items": [
-                ["Spade Key", "Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank", "Fuse - Break Room Hallway"],
-                ["Spade Key", "Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Fuse - Break Room Hallway"]
+                ["Spade Key", "Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"],
+                ["Spade Key", "Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             ]
         }
     },
@@ -339,8 +339,8 @@
         "to": "Roof",
         "condition": {
             "items": [
-                ["Spade Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Fuse - Break Room Hallway", "Square Crank"],
-                ["Spade Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Fuse - Break Room Hallway", "Mechanic Jack Handle"]
+                ["Spade Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"],
+                ["Spade Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             ]
         }
     },
@@ -386,9 +386,7 @@
     { 
         "from": "Water Gate",
         "to": "Upper Waterway",
-        "condition": {
-            "items": ["Rook Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -354,7 +354,7 @@
             "parent_object": "16-229-0-0-ID207",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -365,7 +365,7 @@
             "parent_object": "16-229-0-0-ID209",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -376,7 +376,7 @@
             "parent_object": "16-229-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -601,7 +601,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
+                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion", "Fuse - Main Hall"]
             }
     },
     {

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -53,7 +53,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -61,7 +62,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Standing Police Zombie",
@@ -69,7 +71,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Dark-Haired Zombie",
@@ -197,7 +200,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -205,7 +209,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Cop in the South Side of the Hallway",
@@ -311,7 +316,8 @@
             "original_item": "",
             "item_object": "FenceClimbDog",
             "parent_object": "29-274-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog under fence outside door",
@@ -322,7 +328,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -333,7 +340,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog from vent",
@@ -344,7 +352,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Dark Police Zombie from Window",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Elliot",
+            "name": "Elliot is half the man he used to be",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FEEliot",
@@ -48,7 +48,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "2nd Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Marvin",
+            "name": "Marvin is just pranking us, right?",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_2ndMarvin",
@@ -88,7 +88,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie East Rail",
+            "name": "Female Zombie Upstairs",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_1FECorridor_DepotZombies",
@@ -128,7 +128,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -136,7 +136,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW1Window2nd",
@@ -144,7 +144,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of stairs",
+            "name": "Police Zombie that loves Jumping",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -152,7 +152,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at end of corridor",
+            "name": "Zombie between floors",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
@@ -160,7 +160,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of stairs",
+            "name": "Surprise Zombie from Spade Key room",
             "region": "West Hallway 3F",
             "original_item": "",
             "item_object": "2ndPlaySpadekeyZombie",
@@ -176,7 +176,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -184,7 +184,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Key Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -192,15 +192,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Helicopter Crash Zombie 2",
+            "name": "First Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -208,28 +200,45 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first window",
+            "name": "Second Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+            "parent_object": "16-255-0-0-ID216",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
+            }
     },
     {
             "type": "Boss",
@@ -289,15 +298,12 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
             "parent_object": "29-273-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Diamond Key"]
-            }
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "Action Dog behind fence",
@@ -309,11 +315,14 @@
     },
     {
             "name": "Action Dog under fence outside door",
-            "region": "Generator Room",
+            "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_twinsBlue1",
-            "parent_object": "29-273-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "parent_object": "29-272-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Square Crank"]
+            }
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -345,10 +354,7 @@
             "parent_object": "16-229-0-0-ID207",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
             }
     },
     {
@@ -357,7 +363,10 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID209",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Plaid Shirt Zombie",
@@ -365,7 +374,10 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Munching Zombie",
@@ -373,10 +385,13 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID208",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
-            "name": "Female Zombie from window",
+            "name": "Second Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FEWindow3rd",
@@ -387,12 +402,15 @@
             }
     },
     {
-            "name": "Zombie hitting door",
+            "name": "Peeping Zombie",
             "region": "Press Room",
             "original_item": "",
             "item_object": "emZombie_1FECorriderB",
             "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"conditions": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Plain Clothes Zombie",
@@ -417,7 +435,7 @@
             }
     },
     {
-            "name": "Jumpsuit Zombie from office or window",
+            "name": "Second Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -450,7 +468,7 @@
             }
     },
     {
-            "name": "Bald Police Zombie window",
+            "name": "Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -477,7 +495,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker",
+            "name": "Second Licker",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW-2",
@@ -488,7 +506,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from first Window",
+            "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -499,7 +517,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from mid Window",   
+            "name": "Second Zombie from Center Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window3rd",
@@ -513,7 +531,7 @@
             "name": "Licker",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emLicker_1FW-2",
+            "item_object": "emLicker_1FW2-2",
             "parent_object": "16-431-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -554,19 +572,18 @@
             }
     },
     {
-            "name": "Licker near Maiden Statue",
+            "name": "Licker",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FW2-2",
             "parent_object": "16-265-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Square Crank"]
-            },
-            "excluded": 1
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -577,17 +594,25 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
+            }
+    },
+    {
+            "name": "Skylight Licker",
+            "region": "Art Room",
+            "original_item": "",
+            "item_object": "emLicker_2FEArtRoomLicker",
+            "parent_object": "16-256-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Red Book", "Statue Left Arm"]
             }
     },
     {
@@ -662,18 +687,17 @@
             "parent_object": "17-317-0-8-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-    {
-            "name": "Falling Overweight Zombie",
-            "region": "Waterway Overpass",
-            "original_item": "",
-            "item_object": "Zombie_Waste02_Fall",
-            "parent_object": "17-315-0-2-ID001",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
+	{
+			"name": "Falling Overweight Zombie",
+			"region": "Waterway Overpass",
+			"original_item": "",
+			"item_object": "Zombie_Waste02_FallBefor",
+			"parent_object": "17-315-0-2-ID001",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
                 "items": ["T-Bar Handle"]
-            },
-            "excluded": 1
-    },
+            }
+	},
     {
             "name": "Dark shirt Female Zombie",
             "region": "Upper Waterway",
@@ -682,7 +706,7 @@
             "parent_object": "17-429-0-1-ID006",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -693,7 +717,7 @@
             "parent_object": "17-429-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -704,7 +728,7 @@
             "parent_object": "17-429-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -732,7 +756,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Third G-Adult from sewer hole",
+            "name": "Third G-Adult from Sewer Pipe",
             "region": "Bottom Waterway",
             "original_item": "",
             "item_object": "em6000_Hole",
@@ -748,14 +772,6 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
-            "region": "Bottom Waterway",
-            "original_item": "",
-            "item_object": "Zombie_WasteGAdultArea_man01",
-            "parent_object": "17-325-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
             "name": "Zombie hanging near King Plug",
             "region": "Supplies Storage Room",
             "original_item": "",
@@ -768,7 +784,7 @@
             "region": "Supplies Storage Room",
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
-            "parent_object": "17-327-0-0-ID008",
+            "parent_object": "17-327-0-2-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -777,6 +793,14 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
+            "region": "Bottom Waterway",
+            "original_item": "",
+            "item_object": "Zombie_WasteGAdultArea_man01",
+            "parent_object": "17-325-0-0-ID024",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -829,7 +853,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -854,17 +878,9 @@
             "item_object": "IvyZombie_FirstHang",
             "parent_object": "3-411-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+    }, 
     {
-            "name": "First Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_AfterFall",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },    
-    {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -872,7 +888,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
@@ -880,7 +896,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy the Fourth",
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
@@ -888,12 +904,26 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy No. 5",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
+    },   
+    {
+            "name": "Second Ivy after using Dispersal Cartridge",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_AfterFall",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "name": "Short Hair Lab Coat Zombie",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -408,7 +408,7 @@
             "item_object": "emZombie_1FECorriderB",
             "parent_object": "16-232-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-			"conditions": {
+			"condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
             }
     },

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -1057,7 +1057,10 @@
             "original_item": "",
             "item_object": "NakedTyrant",
             "parent_object": "21-373-0-11-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 1",
@@ -1065,7 +1068,10 @@
             "original_item": "",
             "item_object": "EscpZombie05",
             "parent_object": "21-422-0-2-ID006",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 2",
@@ -1073,7 +1079,10 @@
             "original_item": "",
             "item_object": "EscpZombie03",
             "parent_object": "21-422-0-0-ID023",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 3",
@@ -1081,7 +1090,10 @@
             "original_item": "",
             "item_object": "EscpZombie06",
             "parent_object": "21-422-0-0-ID025",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 4",
@@ -1089,7 +1101,10 @@
             "original_item": "",
             "item_object": "EscpZombie02",
             "parent_object": "21-422-0-2-ID005",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 5",
@@ -1097,7 +1112,10 @@
             "original_item": "",
             "item_object": "EscpZombie04",
             "parent_object": "21-422-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 6",
@@ -1105,7 +1123,10 @@
             "original_item": "",
             "item_object": "EscpZombie01",
             "parent_object": "21-422-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -139,7 +139,7 @@
             "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1FW1Window2nd",
+            "item_object": "emZombie1FW1Window2nd",
             "parent_object": "16-226-0-0-ID014",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
@@ -156,7 +156,7 @@
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
-            "parent_object": "16-253-0-0-ID200",
+            "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -208,10 +208,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Zombie from South Window",
+            "name": "Cop in the South Side of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW4Window",
+            "item_object": "emZombie1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -219,10 +219,10 @@
             }
     },
     {
-            "name": "First Zombie from Center Window",
+            "name": "Jumpsuit Zombie in the Center of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW3Window",
+            "item_object": "emZombie1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -233,7 +233,7 @@
             "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FWAdd",
+            "item_object": "emZombie1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -294,7 +294,7 @@
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
-            "parent_object": "29-273-0-2-ID004",
+            "parent_object": "29-273-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -498,7 +498,7 @@
             "name": "Second Licker",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emLicker_1FW-2",
+            "item_object": "emLicker_1FW2-2",
             "parent_object": "16-125-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -971,7 +971,8 @@
             "original_item": "",
             "item_object": "ZombieTAreaLowTemperature",
             "parent_object": "3-414-0-1-ID304",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Lab Coat Zombie at bottom of stairs",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -129,7 +129,7 @@
     },
     {
             "name": "Police Zombie Playing Dead",
-            "region": "East Hallway 1F",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
             "parent_object": "16-431-0-0-ID213",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -97,7 +97,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway 1F",
+            "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW",
             "parent_object": "16-125-0-3-nil",

--- a/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/enemies.json
@@ -387,7 +387,7 @@
             "parent_object": "16-229-0-0-ID208",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -150,7 +150,9 @@
         "region": "Press Room",
         "original_item": "Flamethrower Fuel",
         "condition": {
-            "items": ["Fuse - Main Hall", "Film - Hiding Place"]
+            "items": [
+			["Fuse - Main Hall", "Film - Hiding Place"], ["Spade Key", "Film - Hiding Place"]
+			]
         },    
         "item_object": "sm70_110",
         "parent_object": "ItemPos_TreasureA_Leon",

--- a/reframework/data/ArchipelagoRE2R/leon/b/locations.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/locations.json
@@ -2448,7 +2448,9 @@
         "name": "Final Hit on Super Tyrant",
         "region": "Path to Super Tyrant",
         "original_item": "Anti-tank Rocket",
-        "condition": {},    
+        "condition": {
+            "items": ["Joint Plug"]
+        },
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",

--- a/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
@@ -393,9 +393,7 @@
     { 
         "from": "Water Gate",
         "to": "Upper Waterway",
-        "condition": {
-            "items": ["Rook Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",

--- a/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
+++ b/reframework/data/ArchipelagoRE2R/leon/b/region_connections.json
@@ -231,13 +231,13 @@
         "to": "Side Stairs"
     },
 	{ 
-        "from": "Main Hall",
-        "to": "Waiting Room",
+        "from": "Waiting Room",
+        "to": "Main Hall",
         "condition": {}
     },
     { 
-        "from": "Waiting Room",
-        "to": "East Hallway 2F",
+        "from": "East Hallway 2F",
+        "to": "Waiting Room",
         "condition": {
             "items": ["Spade Key"]
         }


### PR DESCRIPTION
Plethora of enemy fixes across all scenarios;
-Fixes the broken G1 check for both Claire scenarios
-Fixes logic issues with enemies in the initial rooms of the RPD on both B scenarios so as to not have your main hall fuse or spade key sitting on an enemy check that is unreachable until later in the game, causing your world to be completely bricked without cheating the item in
-Some check names have been rewritten for parity - some enemies had a different check name between characters/scenarios despite being the same enemy previously
-Truly missable enemy checks have been excluded - this is largely focussed in the RPD with things like the first zombie that comes through the window in the west wing before entering the ops room that despawns once you return to marvin, or the helicopter crash zombies in the 2f east wing corridor that despawn once you go down the ladder from 3f to access the roof as examples. 

This isnt a complete exhaustive list by any means, but it has been tested a fair bit and tweaked to get to this point. 